### PR TITLE
some methods for handling singular resource case

### DIFF
--- a/lib/resty/repo.ex
+++ b/lib/resty/repo.ex
@@ -59,13 +59,13 @@ defmodule Resty.Repo do
   end
 
   @doc """
-  Alias for `all/1`. Should be used with singular resource.
+  Alias for `all/2`. Should be used with singular resource.
   """
-  def show(module), do: all(module)
+  def show(module, options \\ []), do: all(module, options)
   def show!(module), do: all!(module)
 
   @doc """
-  Same as `all/1` but raise in case of error.
+  Same as `all/2` with empty `options` param but raise in case of error.
   """
   @spec all!(Resty.Resource.mod()) :: [Resty.Resource.t()]
   def all!(module) do
@@ -79,11 +79,13 @@ defmodule Resty.Repo do
   Return all the resources returned by the api.
   """
   @spec all(Resty.Resource.mod()) :: {:ok, [Resty.Resource.t()]} | {:error, Exception.t()}
-  def all(module) do
+  def all(module, options \\ []) do
+    headers = options[:headers] || []
+
     request = %Request{
       method: :get,
       url: Resource.url_for(module),
-      headers: module.headers()
+      headers: module.headers() ++ headers
     }
 
     case request |> Auth.authenticate(module) |> Connection.send(module) do
@@ -215,13 +217,14 @@ defmodule Resty.Repo do
   @doc """
   Update without id. Should be used with singular resource.
   """
-  def update(resource = %{__struct__: module}) do
+  def update(resource = %{__struct__: module}, options \\ []) do
+    headers = options[:headers] || []
     resource = resource |> Serializer.serialize()
 
     request = %Request{
       method: :put,
       url: Resource.url_for(module),
-      headers: module.headers(),
+      headers: module.headers() ++ headers,
       body: resource
     }
 

--- a/test/resty/repo_test.exs
+++ b/test/resty/repo_test.exs
@@ -43,6 +43,26 @@ defmodule Resty.RepoTest do
     end
   end
 
+  test "show :ok" do
+    assert {:ok, [%Post{id: 1} | _]} = Repo.show(Post)
+    assert {:ok, []} = Repo.show(Subscriber)
+  end
+
+  test "show :error" do
+    assert {:error, %Error.ResourceNotFound{}} = Repo.show(Like)
+  end
+
+  test "show! ok" do
+    assert [%Post{id: 1} | _] = Repo.show!(Post)
+    assert [] = Repo.all!(Subscriber)
+  end
+
+  test "show! error" do
+    assert_raise Error.ResourceNotFound, fn ->
+      Repo.all!(Like)
+    end
+  end
+
   test "all :ok" do
     assert {:ok, [%Post{id: 1} | _]} = Repo.all(Post)
     assert {:ok, []} = Repo.all(Subscriber)
@@ -135,6 +155,14 @@ defmodule Resty.RepoTest do
 
       post |> Repo.save!()
     end
+  end
+
+  test "update singular :ok" do
+    {:ok, post} = Repo.find(Post, 1)
+
+    {:ok, updated_post} = %{post | name: "updated"} |> Repo.update()
+
+    assert "updated" == updated_post.name
   end
 
   test "update_attribute :ok" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -17,6 +17,7 @@ defmodule MockedConnection do
   mock(:get, "site.tld/posts/1", {:ok, @first_post |> Jason.encode!()})
   mock(:get, "site.tld/posts/2", {:ok, @second_post |> Jason.encode!()})
   mock(:post, "site.tld/posts")
+  mock(:put, "site.tld/posts")
   mock(:put, "site.tld/posts/1")
   mock(:put, "site.tld/posts/2", {:error, Resty.Error.ResourceInvalid.new()})
   mock(:delete, "site.tld/posts/1")


### PR DESCRIPTION
- show: alias for `all`
- update: behaves as `save` but without `id`